### PR TITLE
#76 Автопостинг новостей в Facebook

### DIFF
--- a/BioEngine.sln
+++ b/BioEngine.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Search", "src\Search\BioEng
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BioEngine.Web", "src\Web\BioEngine.Web.csproj", "{41FD8F9B-A53C-4FAF-B148-335C76EE7A83}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BioEngine.Social.Test", "src\BioEngine.Social.Test\BioEngine.Social.Test.csproj", "{7AE14EFA-C077-4C35-9A25-DF81A510BECA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{41FD8F9B-A53C-4FAF-B148-335C76EE7A83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41FD8F9B-A53C-4FAF-B148-335C76EE7A83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41FD8F9B-A53C-4FAF-B148-335C76EE7A83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AE14EFA-C077-4C35-9A25-DF81A510BECA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AE14EFA-C077-4C35-9A25-DF81A510BECA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AE14EFA-C077-4C35-9A25-DF81A510BECA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AE14EFA-C077-4C35-9A25-DF81A510BECA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BioEngine.Social.Test/BioEngine.Social.Test.csproj
+++ b/src/BioEngine.Social.Test/BioEngine.Social.Test.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02"/>
+        <PackageReference Include="xunit" Version="2.2.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Social\BioEngine.Social.csproj"/>
+    </ItemGroup>
+    <PropertyGroup>
+        <UserSecretsId>6669c488-cfea-43d0-a0f5-a50c9ee9ca59</UserSecretsId>
+    </PropertyGroup>
+</Project>

--- a/src/BioEngine.Social.Test/FacebookTest.cs
+++ b/src/BioEngine.Social.Test/FacebookTest.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BioEngine.Social.Test
+{
+    public class FacebookTest
+    {
+        private readonly ServiceProvider _services;
+
+        public FacebookTest()
+        {
+            var config = new ConfigurationBuilder()
+                .AddUserSecrets("6669c488-cfea-43d0-a0f5-a50c9ee9ca59")
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddBioEngineSocial(config);
+            services.AddLogging();
+
+            _services = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public async Task TestPostLink()
+        {
+            var facebookService = _services.GetService<FacebookService>();
+
+            var link = new Uri("https://www.bioware.ru/");
+
+            var postId = await facebookService.PostLink(link);
+
+            Assert.NotEmpty(postId);
+
+            var deleted = await facebookService.DeletePost(postId);
+
+            Assert.True(deleted);
+        }
+    }
+}

--- a/src/Common/Models/News.cs
+++ b/src/Common/Models/News.cs
@@ -67,6 +67,9 @@ namespace BioEngine.Common.Models
 
         [Required]
         public long TwitterId { get; set; }
+        
+        [Required]
+        public string FacebookId { get; set; }
 
         [ForeignKey(nameof(AuthorId))]
         public virtual User Author { get; set; }

--- a/src/Data/DB/Migrations/20171124063427_add_facebook_id_to_news.Designer.cs
+++ b/src/Data/DB/Migrations/20171124063427_add_facebook_id_to_news.Designer.cs
@@ -11,9 +11,10 @@ using System;
 namespace BioEngine.Data.DB.Migrations
 {
     [DbContext(typeof(BWContext))]
-    partial class BWContextModelSnapshot : ModelSnapshot
+    [Migration("20171124063427_add_facebook_id_to_news")]
+    partial class add_facebook_id_to_news
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Data/DB/Migrations/20171124063427_add_facebook_id_to_news.cs
+++ b/src/Data/DB/Migrations/20171124063427_add_facebook_id_to_news.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace BioEngine.Data.DB.Migrations
+{
+    public partial class add_facebook_id_to_news : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "facebook_id",
+                table: "be_news",
+                nullable: true,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "facebook_id",
+                table: "be_news");
+        }
+    }
+}

--- a/src/Data/News/Commands/ManageNewsFacebookCommand.cs
+++ b/src/Data/News/Commands/ManageNewsFacebookCommand.cs
@@ -1,0 +1,17 @@
+﻿using BioEngine.Data.Core;
+using BioEngine.Social;
+
+namespace BioEngine.Data.News.Commands
+{
+    public class ManageNewsFacebookCommand : QueryBase<bool>
+    {
+        public ManageNewsFacebookCommand(Common.Models.News news, FacebookOperationEnum operation)
+        {
+            News = news;
+            Operation = operation;
+        }
+
+        public Common.Models.News News { get; }
+        public FacebookOperationEnum Operation { get; }
+    }
+}

--- a/src/Data/News/Handlers/DeleteNewsHandler.cs
+++ b/src/Data/News/Handlers/DeleteNewsHandler.cs
@@ -26,6 +26,11 @@ namespace BioEngine.Data.News.Handlers
                 await Mediator.Send(new DeleteTweetCommand(command.Model.TwitterId));
             }
 
+            if (!string.IsNullOrEmpty(command.Model.FacebookId))
+            {
+                await Mediator.Send(new DeleteFacebookPostCommand(command.Model.FacebookId));
+            }
+
             //delete news
             DBContext.Remove(command.Model);
             await DBContext.SaveChangesAsync();

--- a/src/Data/News/Handlers/ManageNewsFacebookPostHandler.cs
+++ b/src/Data/News/Handlers/ManageNewsFacebookPostHandler.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using BioEngine.Data.Core;
+using BioEngine.Data.News.Commands;
+using BioEngine.Data.Social.Commands;
+using BioEngine.Social;
+using JetBrains.Annotations;
+
+namespace BioEngine.Data.News.Handlers
+{
+    [UsedImplicitly]
+    internal class ManageNewsFacebookPostHandler : QueryHandlerBase<ManageNewsFacebookCommand, bool>
+    {
+        public ManageNewsFacebookPostHandler(HandlerContext<ManageNewsFacebookPostHandler> context) : base(context)
+        {
+        }
+
+        protected override async Task<bool> RunQueryAsync(ManageNewsFacebookCommand message)
+        {
+            var result = false;
+            switch (message.Operation)
+            {
+                case FacebookOperationEnum.CreateOrUpdate:
+                    if (!string.IsNullOrEmpty(message.News.FacebookId))
+                    {
+                        var deleted = await Mediator.Send(new DeleteFacebookPostCommand(message.News.FacebookId));
+                        if (!deleted)
+                        {
+                            throw new Exception("Can't delete news facebook post");
+                        }
+                    }
+
+                    var newPostId = await Mediator.Send(new PublishFacebookLinkCommand(message.News.PublicUrl));
+                    if (!string.IsNullOrEmpty(newPostId))
+                    {
+                        message.News.FacebookId = newPostId;
+                        result = true;
+                    }
+
+                    break;
+                case FacebookOperationEnum.Delete:
+                    if (!string.IsNullOrEmpty(message.News.FacebookId))
+                    {
+                        result = await Mediator.Send(new DeleteFacebookPostCommand(message.News.FacebookId));
+                        if (result)
+                        {
+                            message.News.FacebookId = null;
+                        }
+                    }
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Data/News/Handlers/PublishNewsHandler.cs
+++ b/src/Data/News/Handlers/PublishNewsHandler.cs
@@ -23,11 +23,12 @@ namespace BioEngine.Data.News.Handlers
             command.Model.Pub = 1;
 
             await Mediator.Publish(new CreateOrUpdateNewsForumTopicCommand(command.Model));
-            
+
             DBContext.Update(command.Model);
             await DBContext.SaveChangesAsync();
 
             await Mediator.Send(new ManageNewsTweetCommand(command.Model, TwitterOperationEnum.CreateOrUpdate));
+            await Mediator.Send(new ManageNewsFacebookCommand(command.Model, FacebookOperationEnum.CreateOrUpdate));
 
             await Mediator.Publish(new IndexEntityCommand<Common.Models.News>(command.Model));
 

--- a/src/Data/News/Handlers/UnPublishNewsHandler.cs
+++ b/src/Data/News/Handlers/UnPublishNewsHandler.cs
@@ -24,6 +24,7 @@ namespace BioEngine.Data.News.Handlers
 
             await Mediator.Publish(new CreateOrUpdateNewsForumTopicCommand(command.Model));
             await Mediator.Send(new ManageNewsTweetCommand(command.Model, TwitterOperationEnum.Delete));
+            await Mediator.Send(new ManageNewsFacebookCommand(command.Model, FacebookOperationEnum.Delete));
 
             DBContext.Update(command.Model);
             await DBContext.SaveChangesAsync();

--- a/src/Data/News/Handlers/UpdateNewsHandler.cs
+++ b/src/Data/News/Handlers/UpdateNewsHandler.cs
@@ -23,9 +23,14 @@ namespace BioEngine.Data.News.Handlers
                                 (command.Title != command.Model.Title || command.Url != command.Model.Url);
 
             Mapper.Map(command, command.Model);
-            if (needSocialUpd)
+
+            if (command.Model.TwitterId == 0 || needSocialUpd)
             {
                 await Mediator.Send(new ManageNewsTweetCommand(command.Model, TwitterOperationEnum.CreateOrUpdate));
+            }
+
+            if (string.IsNullOrEmpty(command.Model.FacebookId) || needSocialUpd)
+            {
                 await Mediator.Send(new ManageNewsFacebookCommand(command.Model, FacebookOperationEnum.CreateOrUpdate));
             }
 

--- a/src/Data/News/Handlers/UpdateNewsHandler.cs
+++ b/src/Data/News/Handlers/UpdateNewsHandler.cs
@@ -19,13 +19,14 @@ namespace BioEngine.Data.News.Handlers
 
         protected override async Task<bool> ExecuteCommandAsync(UpdateNewsCommand command)
         {
-            var needTweetUpd = command.Model.Pub == 1 &&
-                               (command.Title != command.Model.Title || command.Url != command.Model.Url);
+            var needSocialUpd = command.Model.Pub == 1 &&
+                                (command.Title != command.Model.Title || command.Url != command.Model.Url);
 
             Mapper.Map(command, command.Model);
-            if (needTweetUpd)
+            if (needSocialUpd)
             {
                 await Mediator.Send(new ManageNewsTweetCommand(command.Model, TwitterOperationEnum.CreateOrUpdate));
+                await Mediator.Send(new ManageNewsFacebookCommand(command.Model, FacebookOperationEnum.CreateOrUpdate));
             }
 
             if (command.Model.Pub == 1)
@@ -33,7 +34,7 @@ namespace BioEngine.Data.News.Handlers
                 await Mediator.Publish(new CreateOrUpdateNewsForumTopicCommand(command.Model));
                 await Mediator.Publish(new IndexEntityCommand<Common.Models.News>(command.Model));
             }
-            
+
             command.Model.LastChangeDate = DateTimeOffset.Now.ToUnixTimeSeconds();
 
             DBContext.Update(command.Model);

--- a/src/Data/Social/Commands/DeleteFacebookPostCommand.cs
+++ b/src/Data/Social/Commands/DeleteFacebookPostCommand.cs
@@ -1,0 +1,14 @@
+﻿using BioEngine.Data.Core;
+
+namespace BioEngine.Data.Social.Commands
+{
+    public class DeleteFacebookPostCommand : QueryBase<bool>
+    {
+        public string PostId { get; }
+
+        public DeleteFacebookPostCommand(string postId)
+        {
+            PostId = postId;
+        }
+    }
+}

--- a/src/Data/Social/Commands/PublishFacebookLinkCommand.cs
+++ b/src/Data/Social/Commands/PublishFacebookLinkCommand.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using BioEngine.Data.Core;
+
+namespace BioEngine.Data.Social.Commands
+{
+    public class PublishFacebookLinkCommand : QueryBase<string>
+    {
+        public Uri Link { get; }
+
+        public PublishFacebookLinkCommand(Uri link)
+        {
+            Link = link;
+        }
+    }
+}

--- a/src/Data/Social/Handlers/DeleteFacebookPostHandler.cs
+++ b/src/Data/Social/Handlers/DeleteFacebookPostHandler.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using BioEngine.Data.Core;
+using BioEngine.Data.Social.Commands;
+using BioEngine.Social;
+using JetBrains.Annotations;
+
+namespace BioEngine.Data.Social.Handlers
+{
+    [UsedImplicitly]
+    internal class DeleteFacebookPostHandler : QueryHandlerBase<DeleteFacebookPostCommand, bool>
+    {
+        private readonly FacebookService _facebookService;
+
+        public DeleteFacebookPostHandler(HandlerContext<DeleteFacebookPostHandler> context,
+            FacebookService facebookService) : base(context)
+        {
+            _facebookService = facebookService;
+        }
+
+        protected override async Task<bool> RunQueryAsync(DeleteFacebookPostCommand command)
+        {
+            var result = await _facebookService.DeletePost(command.PostId);
+
+            return result;
+        }
+    }
+}

--- a/src/Data/Social/Handlers/PublishFacebookLinkHandler.cs
+++ b/src/Data/Social/Handlers/PublishFacebookLinkHandler.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using BioEngine.Data.Core;
+using BioEngine.Data.Social.Commands;
+using BioEngine.Social;
+
+namespace BioEngine.Data.Social.Handlers
+{
+    internal class PublishFacebookLinkHandler : QueryHandlerBase<PublishFacebookLinkCommand, string>
+    {
+        private readonly FacebookService _facebookService;
+
+        public PublishFacebookLinkHandler(HandlerContext<PublishFacebookLinkHandler> context,
+            FacebookService facebookService) : base(context)
+        {
+            _facebookService = facebookService;
+        }
+
+        protected override Task<string> RunQueryAsync(PublishFacebookLinkCommand message)
+        {
+            var postId = _facebookService.PostLink(message.Link);
+
+            return postId;
+        }
+    }
+}

--- a/src/Social/BioEngine.Social.csproj
+++ b/src/Social/BioEngine.Social.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Flurl.Http" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
     <PackageReference Include="TweetinviAPI" Version="2.1.0" />
   </ItemGroup>

--- a/src/Social/FacebookService.cs
+++ b/src/Social/FacebookService.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading.Tasks;
+using Flurl.Http;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Tweetinvi.Core.Extensions;
+
+namespace BioEngine.Social
+{
+    [UsedImplicitly]
+    public class FacebookService
+    {
+        private readonly ILogger<FacebookService> _logger;
+        private readonly FacebookServiceConfiguration _configuration;
+
+        public FacebookService(FacebookServiceConfiguration configuration, ILogger<FacebookService> logger)
+        {
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        public async Task<string> PostLink(Uri link)
+        {
+            _logger.LogDebug("Post new link to facebook");
+            var response =
+                await $"{_configuration.ApiURL}/{_configuration.PageId}/feed"
+                    .AddParameterToQuery("link", link.ToString())
+                    .AddParameterToQuery("access_token", _configuration.AccessToken)
+                    .WithTimeout(60)
+                    .PostUrlEncodedAsync(new { });
+            var data = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Error while sending facebook request");
+                throw new Exception($"Bad facebook response: {data}");
+            }
+
+            var postReponse = JsonConvert.DeserializeObject<FacebookNewPostResponse>(data);
+            _logger.LogDebug("Link posted to facebook");
+            return postReponse.Id;
+        }
+
+        public async Task<bool> DeletePost(string postId)
+        {
+            _logger.LogDebug("Delete post from facebook");
+            var response =
+                await $"{_configuration.ApiURL}/{postId}"
+                    .AddParameterToQuery("access_token", _configuration.AccessToken)
+                    .DeleteAsync();
+            var data = await response.Content.ReadAsStringAsync();
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Error while sending facebook request");
+                throw new Exception($"Bad facebook response: {data}");
+            }
+
+            var postReponse = JsonConvert.DeserializeObject<FacebookDeleteResponse>(data);
+            _logger.LogDebug($"Post deleted from facebook: {(postReponse.Success ? "Yes" : "No")}");
+            return postReponse.Success;
+        }
+    }
+
+    public class FacebookNewPostResponse
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    public class FacebookDeleteResponse
+    {
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+    }
+
+    public class FacebookServiceConfiguration
+    {
+        public FacebookServiceConfiguration(string apiUrl, string pageId, string accessToken)
+        {
+            ApiURL = new Uri(apiUrl);
+            PageId = pageId;
+            AccessToken = accessToken;
+        }
+
+        public Uri ApiURL { get; }
+        public string PageId { get; }
+        public string AccessToken { get; }
+    }
+    
+    public enum FacebookOperationEnum
+    {
+        CreateOrUpdate,
+        Delete
+    }
+}

--- a/src/Social/SeviceCollectionExtensions.cs
+++ b/src/Social/SeviceCollectionExtensions.cs
@@ -15,6 +15,14 @@ namespace BioEngine.Social
             ));
 
             services.AddSingleton<TwitterService>();
+
+            services.AddSingleton(new FacebookServiceConfiguration(
+                configuration["BE_FACEBOOK_API_URL"],
+                configuration["BE_FACEBOOK_PAGE_ID"],
+                configuration["BE_FACEBOOK_ACCESS_TOKEN"]
+            ));
+
+            services.AddSingleton<FacebookService>();
         }
     }
 }


### PR DESCRIPTION
Добавил автопостинг новостей в фейсбук. Всё по аналогии с твиттером - у новости появился facebookId, в который пишется айди поста. Когда новость публикуется - создаётся пост в ФБ. Когда обновляется, если у неё поменялся тайтл и урл - старый пост удаляется и создаётся новый. Когда удаляется - удаляется и пост.

Никакой адекватно свежей библиотеки для обещения с фейсбуком из шарпа не нашёл, да и нет в ней особой необходимости. Заюзал http://tmenier.github.io/Flurl/ для удобного построения урлов.

Сделал тест, который проверяет создание и удаление поста.

На локалхосте надо будет сначала накатить миграцию. Но оно люто тормозит, так как при постинге ссылки ФБ пытается скачать для неё всякие тайтлы и прочие картинки и так как мы ему кормим ссылку на локалхост, то оно обтупливается. Возможно стоит что-то с этим сделать. Тест отработает быстро.